### PR TITLE
Baseline as Random Walk. 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -661,47 +661,30 @@ quick_test_subregion:
     models: false
     
     
+# Quick test - Total system-wide counts
 test_totals:
-  inherits: default
-  
+  inherits: quick_test
   spatial:
     level: all
     forecast_totals: true
-    include_species: "all"          # ← Use ALL species for totals
-    include_unknowns: true         # ← Exclude generic codes
-    
   models:
+    mvgam:
+      - baseline
+      - ar
+      - ar_exog
+      - ar_exog_plus      
     fable:
       - baseline
       - arima
       - tslm
       - arima_exog
       - gam
-      
-  run_mvgam: false
-  run_fable: true                   # ← ENABLE FABLE
-  
-  chains: 1
-  burnin: 250
-  samples: 250
-  cv_windows: 2
-  
-  use_ordinal: false                # ← Faster for testing
-  
-  parallel:
-    enabled: false
-    
-  cache:
-    data: true
-    models: false
-  
-  # ADD COMPLETE PLOTS SECTION:
-  plots:
-    forecast_timeseries: true       # ← Enable time series plots
-    skill_over_time: true
-    best_model_counts: true
-    ts_models: ["baseline", "arima", "tslm"]
-    ts_species: ["Total"]           # ← CRITICAL: Plot "Total" not top6
+  run_mvgam: true         
+  run_fable: true
+  chains: 2               
+  burnin: 500
+  samples: 500
+  cv_windows: 3
     
     
     

--- a/models/fable_models.R
+++ b/models/fable_models.R
@@ -70,7 +70,7 @@ make_fable_forecasts <- function(train_data, test_data, models_to_run = NULL,
   model_specs <- character()
   
   if ("baseline" %in% models_to_run) {
-    model_specs <- c(model_specs, "baseline = MEAN(count)")
+    model_specs <- c(model_specs, "baseline = RW(count)")                                     #"The future will be like today" (Random Walk)
   }
   if ("arima" %in% models_to_run) {
     model_specs <- c(model_specs, "arima = ARIMA(count)")

--- a/models/mvgam_baseline.R
+++ b/models/mvgam_baseline.R
@@ -3,7 +3,11 @@ fit_mvgam_baseline <- function(train_data, test_data, config) {
   
   tryCatch({
     model <- mvgam(
-      formula = count ~ series,
+      formula = count ~ 1,           
+      trend_model = RW(),            
+      #trend_model = RW() — This makes it a proper random walk baseline (the time-series equivalent of "just predict tomorrow will be like today")
+      #this might want to be modefied? 
+      #check fable null model... 
       data = train_data,
       family = nb(),
       chains = config$chains,


### PR DESCRIPTION
Changing assumptions of the baseline to "the future will be like today", instead of the long term average. https://stats.stackexchange.com/questions/415396/why-naive-prediction-forecasting-is-called-random-walk 